### PR TITLE
Fixing issue with a picture rId being undefined

### DIFF
--- a/source/lib/drawing/picture.js
+++ b/source/lib/drawing/picture.js
@@ -90,7 +90,9 @@ class Picture extends Drawing {
     }
 
     get rId() {
-      return this._rId;
+        return (this._rId)
+            ? this._rId
+            : 'rId' + this._id;
     }
     set rId(rId) {
       this._rId = 'rId' + rId;


### PR DESCRIPTION
#6 introduced a regression issue where pictures were forced to set an rId. If one was not set it would result in a broken image being displayed in Excel.

We should revert to using the picture's id when the rId is not manually set.