### PR TITLE
Use more standard representation of boolean values in cells

### DIFF
--- a/source/lib/cell/index.js
+++ b/source/lib/cell/index.js
@@ -84,22 +84,28 @@ function numberSetter(val) {
 }
 
 function booleanSetter(val) {
-    if (val === undefined || typeof (val.toString().toLowerCase() === 'true' || ((val.toString().toLowerCase() === 'false') ? false : val)) !== 'boolean') {
-        throw new TypeError(util.format('Value sent to Bool function of cells %s was not a bool, it has type of %s and value of %s',
-            JSON.stringify(this.excelRefs),
-            typeof (val),
-            val
-        ));
+    if (val !== true && val !== false) {
+        let valString = val.toString().toLowerCase();
+        if (valString === "true") {
+            val = true;
+        } else if (valString === "false") {
+            val = false;
+        } else {
+            throw new TypeError(util.format('Value sent to Bool function of cells %s was not a bool, it has type of %s and value of %s',
+                JSON.stringify(this.excelRefs),
+                typeof (val),
+                val
+            ));
+        }
     }
-    val = val.toString().toLowerCase() === 'true';
 
     if (!this.merged) {
         this.cells.forEach((c, i) => {
-            c.bool(val.toString());
+            c.bool(val ? '1' : '0');
         });
     } else {
         var c = this.cells[0];
-        c.bool(val.toString());
+        c.bool(val ? '1' : '0');
     }
     return this;
 }

--- a/tests/cell.test.js
+++ b/tests/cell.test.js
@@ -59,7 +59,7 @@ test('Add Boolean to cell', (t) => {
     let thisCell = ws.cells[cell.excelRefs[0]];
     t.ok(thisCell.t === 'b', 'cellType set to boolean');
     t.ok(typeof (thisCell.v) === 'string', 'cell Value is a string');
-    t.ok(thisCell.v === 'true' || thisCell.v === 'false', 'Cell value value is correct');
+    t.ok(thisCell.v === '1' || thisCell.v === '0', 'Cell value value is correct');
 });
 
 test('Add Formula to cell', (t) => {


### PR DESCRIPTION
See https://bugs.documentfoundation.org/show_bug.cgi?id=155046

Unfortunately the OOXML ECMA-376 spec does not ever seem to explicitly mention what is expected for a `<v>` cell value element within a `<c>` cell element where  `t="b"` indicates a boolean value type. But it seems that excel4node's writing the text "true" and "false" instead of the text "0" and "1" within `<v>` elements representing boolean values is uncommon behavior.

With this change, boolean cells now display as expected in LibreOffice Calc and Google Sheets, where previously they did not.

I verified on my system that `npm run test` and `node sample.js && ./validate.sh Excel.xlsx` both run successfully after building.

This is an improved implementation of the same fix as in #59.