### PR TITLE
Add support for print titles (repeated rows or columns)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,34 @@ ws.setPrintArea(1, 1, 5, 3);
 
 ```
 
+##### Worksheet Print Titles
+
+Rows or columns to repeat on every page can be set with
+
+```js
+ws.setPrintTitleRows(startRow, endRow)
+ws.setPrintTitleColumns(startColumn, endColumn)
+```
+
+```javascript
+
+// Sets print area to include all cells between A1 and C5 including C5
+const wb = new xl.Workbook();
+const ws = wb.addWorksheet('Sheet 1');
+
+// This will repeat the first row on the top of every page
+ws.setPrintTitleRows(1, 1);
+
+// This will repeat row 2 to 5 (inclusive) on the top of every page
+ws.setPrintTitleRows(2, 5);
+
+// This will repeat column A on the left of every page
+ws.setPrintTitleColumns(1, 1);
+
+// This will repeat column B to E on the left of every page
+ws.setPrintTitleColumns(2, 5);
+```
+
 ## Rows and Columns
 
 Set custom widths and heights of columns/rows

--- a/source/lib/workbook/builder.js
+++ b/source/lib/workbook/builder.js
@@ -198,6 +198,32 @@ let addWorkbookXML = (promiseObj) => {
           refFormula: `'${name}'!${startCellRef}:${endCellRef}`,
         });
       }
+
+      if (s.printTitleRows || s.printTitleColumns) {
+        let refFormula = ''
+
+        if (s.printTitleRows) {
+          const startRowRef = `$${s.printTitleRows.startRow}`;
+          const endRowRef = `$${s.printTitleRows.endRow}`;
+          refFormula = `'${s.name}'!${startRowRef}:${endRowRef}`
+        }
+
+        if (s.printTitleColumns) {
+          if (refFormula.length > 0) {
+            refFormula += ','
+          }
+
+          const startColRef = `$${utils.getExcelAlpha(s.printTitleColumns.startColumn)}`;
+          const endColRef = `$${utils.getExcelAlpha(s.printTitleColumns.endColumn)}`;
+          refFormula += `'${s.name}'!${startColRef}:${endColRef}`
+        }
+
+        s.wb.definedNameCollection.addDefinedName({
+          name: '_xlnm.Print_Titles',
+          localSheetId: s.localSheetId,
+          refFormula,
+        });
+      }
     });
 
     if (!promiseObj.wb.definedNameCollection.isEmpty) {

--- a/source/lib/worksheet/worksheet.js
+++ b/source/lib/worksheet/worksheet.js
@@ -122,6 +122,8 @@ class Worksheet {
             column: [],
         };
         this.printArea = null;
+        this.printTitleRows = null;
+        this.printTitleColumns = null;
         this.lastUsedRow = 1;
         this.lastUsedCol = 1;
 
@@ -311,10 +313,51 @@ class Worksheet {
             startCol,
             endRow,
             endCol,
-        }
+        };
         return this;
     }
 
+    /**
+     * @method Worksheet.setPrintTitleRows
+     * @param {number} startRow
+     * @param {number} endRow
+     * @returns {Worksheet}
+     */
+    setPrintTitleRows(startRow, endRow) {
+        if (
+            typeof startRow !== 'number' ||
+            typeof endRow !== 'number'
+        ) {
+            this.wb.logger.warn('invalid option sent to setPrintTitleRows method');
+            return;
+        }
+        this.printTitleRows = {
+            startRow,
+            endRow
+        };
+        return this;
+    }
+
+    /**
+     * @method Worksheet.setPrintTitleColumns
+     * @param {number} startColumn
+     * @param {number} endColumn
+     * @returns {Worksheet}
+     */
+    setPrintTitleColumns(startColumn, endColumn) {
+        if (
+            typeof startColumn !== 'number' ||
+            typeof endColumn !== 'number'
+        ) {
+            this.wb.logger.warn('invalid option sent to setPrintTitleColumns method');
+            return;
+        }
+        this.printTitleColumns = {
+            startColumn,
+            endColumn
+        };
+        return this;
+    }
 }
 
 module.exports = Worksheet;

--- a/tests/worksheet.test.js
+++ b/tests/worksheet.test.js
@@ -72,7 +72,7 @@ test('Set Worksheet options', (t) => {
             'verticalDpi': 96
         },
         'sheetView': {
-            'pane': { // Note. Calling .freeze() on a row or column will adjust these values 
+            'pane': { // Note. Calling .freeze() on a row or column will adjust these values
                 'activePane': 'bottomLeft', // one of 'bottomLeft', 'bottomRight', 'topLeft', 'topRight'
                 'state': 'frozen', // one of 'split', 'frozen', 'frozenSplit'
                 'topLeftCell': 'E3', // i.e. 'A1'
@@ -92,7 +92,7 @@ test('Set Worksheet options', (t) => {
             'thickBottom': false, // 'True' if rows have a thick bottom border by default.
             'thickTop': true // 'True' if rows have a thick top border by default.
         },
-        'sheetProtection': { // same as 'Protect Sheet' in Review tab of Excel 
+        'sheetProtection': { // same as 'Protect Sheet' in Review tab of Excel
             'autoFilter': true, // True means that that user will be unable to modify this setting
             'deleteColumns': true,
             'deleteRows': true,
@@ -375,7 +375,7 @@ test('Verify Invalid Worksheet options fail type validation', (t) => {
 });
 
 test('Check worksheet defaultRowHeight behavior', (t) => {
-    // The defaultRowHeight property effects more than its own tag in the XML. 
+    // The defaultRowHeight property effects more than its own tag in the XML.
     // need to check output of sheetFormatPr.customHeight, sheetFormatPr.defaultRowHeight and each row's customHeight attribute
     // With no sheetFormat.customHeight set, the row height should scale to fit the text and ignore the sheetFormatPr.defaultRowHeight value
 
@@ -459,4 +459,51 @@ test('Check worksheet addPageBreak behavior', (t) => {
             t.end();
         });
 
+});
+
+test('Sets print title rows and columns', (t) => {
+    const wb = new xl.Workbook();
+    const ws = wb.addWorksheet('Sheet1');
+
+    ws.setPrintTitleRows(1, 2);
+    ws.setPrintTitleColumns(3, 4);
+
+    t.deepEquals(ws.printTitleRows, {
+        startRow: 1,
+        endRow: 2,
+    });
+
+    t.deepEquals(ws.printTitleColumns, {
+        startColumn: 3,
+        endColumn: 4,
+    });
+
+    t.end();
+});
+
+test('Ignores invalid print title column values', (t) => {
+    const wb = new xl.Workbook();
+    const ws = wb.addWorksheet('Sheet1');
+
+    ws.setPrintTitleColumns('A', 'B');
+
+    t.equals(ws.printTitleColumns, null);
+    t.end();
+});
+
+test('Defines special name _xlnm.Print_Titles when print title rows or columns set', async (t) => {
+    const wb = new xl.Workbook();
+    const ws = wb.addWorksheet('Sheet1');
+
+    ws.setPrintTitleRows(1, 2);
+    ws.setPrintTitleColumns(3, 4);
+
+    const xml = await wb._generateXML();
+    let doc = new DOMParser().parseFromString(xml);
+
+    const definedName = doc.getElementsByTagName('definedName')[0];
+    t.equals(definedName.getAttribute('name'), '_xlnm.Print_Titles');
+    t.equals(definedName.firstChild.nodeValue, "'Sheet1'!$1:$2,'Sheet1'!$C:$D");
+
+    t.end();
 });


### PR DESCRIPTION
This will allow you to specify a range of rows and/or columns to repeat on every printed page. Rows will be repeated on the top of the page, columns will be on the left side of the page.

The special defined name "_xlnm.Print_Titles" is mentioned in §18.2.5 of ECMA-376 5h Edition Part 1 2016 but also earlier versions. (https://www.ecma-international.org/publications-and-standards/standards/ecma-376/)

Fixes https://github.com/natergj/excel4node/issues/171