### PR TITLE
Fix error when the worksheet has both comments and images

### DIFF
--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -530,11 +530,11 @@ let sheetXML = (ws) => {
         .then(_addHyperlinks)
         .then(_addPrintOptions)
         .then(_addPageMargins)
-        .then(_addLegacyDrawing)
         .then(_addPageSetup)
         .then(_addPageBreaks)
         .then(_addHeaderFooter)
         .then(_addDrawing)
+        .then(_addLegacyDrawing)
         .then((promiseObj) => {
             return new Promise((resolve, reject) => {
                 wsXML.end();


### PR DESCRIPTION
Excel does not opens worksheets that have the tag `<drawing>` after the tag `<legacyDrawing>`. Moving the `<legacyDrawing>` tag to be generated after the `<drawing>` tag fixes the issue.

Fixes #53