### PR TITLE
Performance optimization adding styles

### DIFF
--- a/source/lib/workbook/workbook.js
+++ b/source/lib/workbook/workbook.js
@@ -238,13 +238,14 @@ class Workbook {
      * @returns {Style}
      */
     createStyle(opts) {
-        const thisStyle = new Style(this, opts);
-        const lookupKey = JSON.stringify(thisStyle.toObject());
+        const lookupKey = JSON.stringify(opts);
 
         // Use existing style if one exists
         if (this.stylesLookup.get(lookupKey)) {
             return this.stylesLookup.get(lookupKey);
         }
+        
+        const thisStyle = new Style(this, opts);
 
         this.stylesLookup.set(lookupKey, thisStyle);
         const index = this.styles.push(thisStyle) - 1;


### PR DESCRIPTION
When adding styles to a large number of cells, calling `new Style()` each time to check if the style exists is slow.  Instead, the stringified style options are used as the lookup key before calling `new Style()`.

For my use case,  I had 35000+ rows, with 10 columns each.  This optimization sped up generation by 30-40%.

Ran tests and all passed.