### PR TITLE
feat!: replace uuid package with nodesJS native crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "xpath.js": "^1.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "lodash.reduce": "^4.6.0",
         "lodash.uniqueid": "^4.0.1",
         "mime": "^3.0.0",
-        "uuid": "^9.0.0",
         "xmlbuilder": "^15.1.1"
       },
       "devDependencies": {
@@ -35,7 +34,7 @@
         "xpath.js": "^1.1.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5163,14 +5162,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9179,11 +9170,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.2",
   "description": "Library to create Formatted Excel Files.",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "excel",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "lodash.reduce": "^4.6.0",
     "lodash.uniqueid": "^4.0.1",
     "mime": "^3.0.0",
-    "uuid": "^9.0.0",
     "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.2",
   "description": "Library to create Formatted Excel Files.",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=14.17.0"
   },
   "keywords": [
     "excel",

--- a/source/lib/classes/comment.js
+++ b/source/lib/classes/comment.js
@@ -1,5 +1,4 @@
-// const uuid = require('uuid/v4');
-const { v4: uuid } = require('uuid');
+const { randomUUID } = require('crypto');
 const utils = require('../utils');
 
 // §18.7.3 Comment
@@ -7,7 +6,7 @@ class Comment {
     constructor(ref, comment, options = {}) {
         this.ref = ref;
         this.comment = comment;
-        this.uuid = '{' + uuid().toUpperCase() + '}';
+        this.uuid = '{' + randomUUID().toUpperCase() + '}';
         this.row = utils.getExcelRowCol(ref).row;
         this.col = utils.getExcelRowCol(ref).col;
         this.marginLeft = options.marginLeft || ((this.col) * 88 + 8) + 'pt';


### PR DESCRIPTION
- **Removed 3rd Party Dependency**: The previously used third-party library for generating v4 UUID strings has been removed. The [UUID](https://www.npmjs.com/package/uuid) package itself notes:
  > [!NOTE] Only interested in creating a version 4 UUID? You might be able to use [crypto.randomUUID()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), eliminating the need to install this library.
  
  Since we only utilized it for generating v4 UUID strings, removing this dependency reduces the number of packages we need to maintain.

- **Bumped Minimum Node Version**: The minimum Node.js version has been increased from `14.0.0` to `14.17.0`, as this is the version in which `randomUUID` was introduced. More details can be found in the [Node v14 documentation](https://nodejs.org/docs/latest-v14.x/api/crypto.html#crypto_crypto_randomuuid_options).
